### PR TITLE
Rudimentary support for embers

### DIFF
--- a/src/main/resources/assets/dsurround/data/forge.json
+++ b/src/main/resources/assets/dsurround/data/forge.json
@@ -179,7 +179,8 @@
 				"doorSteel",
 				"doorTin",
 				"blockWroughtIron",
-				"blockVoid"
+				"blockVoid",
+				"blockDawnstone"
 			]
 			
 		},

--- a/src/main/resources/assets/dsurround/data/forge.json
+++ b/src/main/resources/assets/dsurround/data/forge.json
@@ -195,7 +195,8 @@
 				"slabBamboo",
 				"stairBamboo",
 				"craftingTableWood",
-				"plankWood"
+				"plankWood",
+				"bookshelf"
 			]
 			
 		},


### PR DESCRIPTION
Placed dawnstone as a hard metal entry.

Due to the amount of content that was wiped between the two versions, I'm probably not going to dredge up anything else relevant for quite some time.