### PR TITLE
Porting over neglected definitions

### DIFF
--- a/src/main/resources/assets/dsurround/data/mcp.json
+++ b/src/main/resources/assets/dsurround/data/mcp.json
@@ -1098,7 +1098,9 @@
 			"acousticProfile": "#sapling",
 			"dictionaryEntries": [
 				"treeSaplings",
-				"saplingTree"
+				"saplingTree",
+				"treeSapling",
+				"sapling"
 			]
 		},
 		{

--- a/src/main/resources/assets/dsurround/data/mcp.json
+++ b/src/main/resources/assets/dsurround/data/mcp.json
@@ -1108,7 +1108,8 @@
 			"dictionaryEntries": [
 				"treeLeaves",
 				"leavesTree",
-				"treeBambooLeaves"
+				"treeBambooLeaves",
+				"leaves"
 			]
 		},
 		{


### PR DESCRIPTION
Minetweaker definitions are not needed due to new features, only these sapling definitions, which have been forgotten in the transition.