### PR TITLE
Fix and update Galacticraft cfg

### DIFF
--- a/src/main/resources/assets/dsurround/data/galacticraftcore.json
+++ b/src/main/resources/assets/dsurround/data/galacticraftcore.json
@@ -19,10 +19,10 @@
 			"_comment": "Galacticraft Mars",
 			"soundReset": true,
 			"dust": true,
-			"dustColor": "204,185,102",
+			"dustColor": "131,100,89",
 			"fog": true,
-			"fogDensity": 0.80,
-			"fogColor": "64,128,64",
+			"fogDensity": 0.3,
+			"fogColor": "217,173,112",
 			"sounds": [
 				{
 					"sound": "dsurround:wind",
@@ -43,10 +43,10 @@
 			"_comment": "Galacticraft Venus",
 			"soundReset": true,
 			"dust": true,
-			"dustColor": "204,185,102",
+			"dustColor": "89,87,87",
 			"fog": true,
-			"fogDensity": 0.18,
-			"fogColor": "64,128,64",
+			"fogDensity": 0.6,
+			"fogColor": "255,211,92",
 			"sounds": [
 				{
 					"sound": "dsurround:wind",
@@ -82,11 +82,30 @@
 		}
 	],
 	"footsteps": {
+		"galacticraftcore:basic_block_moon^3": "gravel",
+		"galacticraftcore:basic_block_moon^4": "stone",
 		"galacticraftcore:basic_block_moon^5": "snow",
+		"galacticraftplanets:mars^0": "ore",
+		"galacticraftplanets:mars^1": "ore",
+		"galacticraftplanets:mars^2": "ore",
+		"galacticraftplanets:mars^3": "ore",
+		"galacticraftplanets:mars^4": "stone",
 		"galacticraftplanets:mars^5": "gravel",
 		"galacticraftplanets:mars^6": "dirt",
+		"galacticraftplanets:mars^7": "brickstone",
 		"galacticraftplanets:venus^0": "dirt",
-		"galacticraftplanets:venus^1": "dirt",
-		"galacticraftplanets:venus^3": "gravel"
+		"galacticraftplanets:venus^1": "bedrock",
+		"galacticraftplanets:venus^2": "quicksand",
+		"galacticraftplanets:venus^3": "gravel",
+		"galacticraftplanets:venus^4": "brickstone",
+		"galacticraftplanets:venus^5": "brickstone",
+		"galacticraftplanets:venus^6": "ore",
+		"galacticraftplanets:venus^7": "ore",
+		"galacticraftplanets:venus^8": "ore",
+		"galacticraftplanets:venus^9": "ore",
+		"galacticraftplanets:venus^10": "ore",
+		"galacticraftplanets:venus^11": "ore",
+		"galacticraftplanets:spout": "dirt",
+		"galacticraftplanets:venus_rock_scorched": "dirt"
 	}
 }


### PR DESCRIPTION
Fixes Galacticraft Mars green fog (issue #140).
Updates fog and dust values.
Updates and adds more footstep sounds.