### PR TITLE
Added clientSideOnly = true to @Mod annotation

### DIFF
--- a/src/main/java/org/blockartistry/DynSurround/DSurround.java
+++ b/src/main/java/org/blockartistry/DynSurround/DSurround.java
@@ -64,7 +64,7 @@ import net.minecraftforge.fml.common.network.NetworkCheckHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-@net.minecraftforge.fml.common.Mod(modid = DSurround.MOD_ID, useMetadata = true, dependencies = DSurround.DEPENDENCIES, version = DSurround.VERSION, acceptedMinecraftVersions = DSurround.MINECRAFT_VERSIONS, guiFactory = DSurround.GUI_FACTORY, updateJSON = DSurround.UPDATE_URL, certificateFingerprint = DSurround.FINGERPRINT)
+@net.minecraftforge.fml.common.Mod(modid = DSurround.MOD_ID, useMetadata = true, dependencies = DSurround.DEPENDENCIES, version = DSurround.VERSION, acceptedMinecraftVersions = DSurround.MINECRAFT_VERSIONS, guiFactory = DSurround.GUI_FACTORY, updateJSON = DSurround.UPDATE_URL, certificateFingerprint = DSurround.FINGERPRINT, clientSideOnly = true)
 public class DSurround {
 	public static final String MOD_ID = "dsurround";
 	public static final String API_ID = MOD_ID + "API";


### PR DESCRIPTION
This will stop servers trying to load the mod, avoiding a ClassNotFoundException with client-only classes.