### PR TITLE
Mod-friendly PotionHUD

### DIFF
--- a/src/main/java/org/orecruncher/dsurround/client/hud/PotionHUD.java
+++ b/src/main/java/org/orecruncher/dsurround/client/hud/PotionHUD.java
@@ -218,6 +218,13 @@ public class PotionHUD extends GuiOverlay {
 				final int l = potion.getStatusIconIndex();
 				this.drawTexturedModalRect(guiLeft + 6, guiTop + 7, 0 + l % 8 * 18, 198 + l / 8 * 18, 18, 18);
 			}
+			else {
+				try {
+					potion.getPotion().renderHUDEffect(guiLeft + 3, guiTop + 4, potion.getPotionEffect(), mc, 1.0F);
+				} catch (final Exception ex) {
+					;
+				}
+			}
 
 			try {
 				potion.getPotion().renderInventoryEffect(guiLeft, guiTop, potion.getPotionEffect(), mc);


### PR DESCRIPTION
This gives mod potions a chance to render their icons in Dynamic Surroundings' potion HUD.

hasStatusIcon() is commonly false for mod potions that override renderHUDEffect() and renderInventoryEffect(), as seen here: https://github.com/Choonster-Minecraft-Mods/TestMod3/blob/1.12.2/src/main/java/choonster/testmod3/potion/PotionTestMod3.java